### PR TITLE
Feature/bug 24823 alt deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
   <artifactId>maven-deployer-extension</artifactId>
   <version>0.3.1-GAGGLE-SNAPSHOT</version>
 
-
   <name>The Maven Deployer Extension.</name>
   <description>Deploy artifacts at the end of the Maven session which 
       solved deployAtEnd/installAtEnd configuration.</description>
@@ -20,8 +19,8 @@
   <properties>
     <smpp.component>maven-deployer-extension</smpp.component>
     <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <!-- Must be overwritten in every project. -->
@@ -58,7 +57,7 @@
         ! We need at least 3.0.3 cause the AbstractEventSpy has been 
         ! introduced in this version first.
         !
-        ! Update:  working to resolve linkage error  MR
+        ! Updated to 3.3.1 due ot linkage error -MR
        -->
       <version>3.3.1</version>
       <scope>provided</scope>
@@ -77,6 +76,30 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-artifact-transfer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.3.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.3.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>2.21.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.21.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -106,18 +129,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+      </plugin>
     </plugins>
   </build>
   <profiles>
     <profile>
       <id>run-its</id>
+      <activation>
+        <!-- Things aren't invoking for me: MR -->
+        <activeByDefault>false</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>
             <groupId>org.codehaus.gmaven</groupId>
             <artifactId>gmaven-plugin</artifactId>
             <configuration>
-              <debug>true</debug>
               <verbose>true</verbose>
               <stacktrace>true</stacktrace>
               <defaultScriptExtension>.groovy</defaultScriptExtension>
@@ -164,11 +194,11 @@
                 <extraArtifact>com.beust:jcommander:1.48:jar</extraArtifact>
                 <extraArtifact>org.testng:testng:6.9.8:jar</extraArtifact>
                 <extraArtifact>org.assertj:assertj-core:2.1.0:jar</extraArtifact>
-                <extraArtifact>org.apache.maven.surefire:surefire-testng:2.19.1:jar</extraArtifact>
+                <extraArtifact>org.apache.maven.surefire:surefire-testng:2.22.1:jar</extraArtifact>
                 <extraArtifact>org.apache.maven.plugins:maven-install-plugin:2.5.2:maven-plugin</extraArtifact>
                 <extraArtifact>org.apache.maven.plugins:maven-assembly-plugin:3.0.0:maven-plugin</extraArtifact>
-                <extraArtifact>org.apache.maven.plugins:maven-failsafe-plugin:2.19.1:maven-plugin</extraArtifact>
-                <extraArtifact>org.apache.maven.plugins:maven-surefire-plugin:2.19.1:maven-plugin</extraArtifact>
+                <extraArtifact>org.apache.maven.plugins:maven-failsafe-plugin:2.22.1:maven-plugin</extraArtifact>
+                <extraArtifact>org.apache.maven.plugins:maven-surefire-plugin:2.22.1:maven-plugin</extraArtifact>
                 <extraArtifact>org.apache.maven.plugins:maven-deploy-plugin:2.8.2:maven-plugin</extraArtifact>
                 <extraArtifact>org.apache.maven:maven-model:3.1.1:jar</extraArtifact>
               </extraArtifacts>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,8 @@
 
   <groupId>com.soebes.maven.extensions</groupId>
   <artifactId>maven-deployer-extension</artifactId>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.3.1-GAGGLE-SNAPSHOT</version>
+
 
   <name>The Maven Deployer Extension.</name>
   <description>Deploy artifacts at the end of the Maven session which 
@@ -55,9 +56,11 @@
       <artifactId>maven-core</artifactId>
       <!--
         ! We need at least 3.0.3 cause the AbstractEventSpy has been 
-        ! introduced in this version first. 
+        ! introduced in this version first.
+        !
+        ! Update:  working to resolve linkage error  MR
        -->
-      <version>3.0.3</version>
+      <version>3.3.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -114,7 +117,7 @@
             <groupId>org.codehaus.gmaven</groupId>
             <artifactId>gmaven-plugin</artifactId>
             <configuration>
-              <debug>false</debug>
+              <debug>true</debug>
               <verbose>true</verbose>
               <stacktrace>true</stacktrace>
               <defaultScriptExtension>.groovy</defaultScriptExtension>

--- a/src/main/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolver.java
+++ b/src/main/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolver.java
@@ -30,22 +30,12 @@ public class ArtifactRepositoryResolver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactRepository.class);
 
-    public ArtifactRepository resolveArtifactRepository(ExecutionEvent executionEvent)
+    public ArtifactRepository resolveArtifactRepository(ExecutionEvent executionEvent, Properties props)
             throws MojoFailureException, MojoExecutionException {
 
-
-
-
-
-        Properties props = executionEvent.getSession().getRequest().getSystemProperties();
-        if (props == null) {
-            props = new Properties();
-        }
-        if (executionEvent.getSession().getRequest().getUserProperties() != null ) {
-            props.putAll(executionEvent.getSession().getRequest().getUserProperties());
-        }
-
-
+        //
+        // Manually pull in props.
+        //
         String altReleaseDeploymentRepository = props.getProperty(ALT_RELEASE_DEPLOYMENT_REPOSITORY);
         String altSnapshotDeploymentRepository = props.getProperty(ALT_SNAPSHOT_DEPLOYMENT_REPOSITORY);
         String altDeploymentRepository = props.getProperty(ALT_DEPLOYMENT_REPOSITORY);
@@ -69,6 +59,14 @@ public class ArtifactRepositoryResolver {
         return getDeploymentRepository(pdr);
     }
 
+    /**
+     * Code Researched from:  <a href="https://github.com/apache/maven-deploy-plugin/blob/maven-deploy-plugin-3.0.0-M1/src/main/java/org/apache/maven/plugins/deploy/DeployMojo.java>
+     *     MavenDeployMojo.java</a>
+     * @param pdr
+     * @return
+     * @throws MojoExecutionException
+     * @throws MojoFailureException
+     */
     protected ArtifactRepository getDeploymentRepository( ProjectDeployerRequest pdr )
 
             throws MojoExecutionException, MojoFailureException

--- a/src/main/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolver.java
+++ b/src/main/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolver.java
@@ -3,7 +3,6 @@ package com.soebes.maven.extensions.deployer;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.inject.Named;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
@@ -17,7 +16,6 @@ import org.apache.maven.shared.transfer.project.deploy.ProjectDeployerRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Named
 public class ArtifactRepositoryResolver {
 
     public static final String ALT_DEPLOYMENT_REPOSITORY = "altDeploymentRepository";

--- a/src/main/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolver.java
+++ b/src/main/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolver.java
@@ -1,0 +1,138 @@
+package com.soebes.maven.extensions.deployer;
+
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.inject.Named;
+import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.transfer.project.deploy.ProjectDeployerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Named
+public class ArtifactRepositoryResolver {
+
+    public static final String ALT_DEPLOYMENT_REPOSITORY = "altDeploymentRepository";
+    public static final String ALT_SNAPSHOT_DEPLOYMENT_REPOSITORY = "altSnapshotDeploymentRepository";
+    public static final String ALT_RELEASE_DEPLOYMENT_REPOSITORY = "altReleaseDeploymentRepository";
+    public static final String RETRY_FAILED_DEPLOYMENT_COUNT = "retryFailedDeploymentCount";
+
+
+    private static final Pattern ALT_REPO_SYNTAX_PATTERN = Pattern.compile( "(.+)::(.+)" );
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactRepository.class);
+
+    public ArtifactRepository resolveArtifactRepository(ExecutionEvent executionEvent)
+            throws MojoFailureException, MojoExecutionException {
+
+
+
+
+
+        Properties props = executionEvent.getSession().getRequest().getSystemProperties();
+        if (props == null) {
+            props = new Properties();
+        }
+        if (executionEvent.getSession().getRequest().getUserProperties() != null ) {
+            props.putAll(executionEvent.getSession().getRequest().getUserProperties());
+        }
+
+
+        String altReleaseDeploymentRepository = props.getProperty(ALT_RELEASE_DEPLOYMENT_REPOSITORY);
+        String altSnapshotDeploymentRepository = props.getProperty(ALT_SNAPSHOT_DEPLOYMENT_REPOSITORY);
+        String altDeploymentRepository = props.getProperty(ALT_DEPLOYMENT_REPOSITORY);
+        int retryFailedDeploymentCount = Integer.parseInt(props.getProperty(RETRY_FAILED_DEPLOYMENT_COUNT,"1"));
+
+        LOGGER.debug("Deployment settins from project:\n\t"
+                        + "altReleaseDeploymentRepository={}\n\t"
+                        + ", altSnapshotDeploymentRepository={}\n\t"
+                        + ", altDeploymentRepository={}\n\t"
+                        + ", retryFailedDeploymentCount={}",
+                altReleaseDeploymentRepository, altSnapshotDeploymentRepository,altDeploymentRepository,retryFailedDeploymentCount);
+
+
+        ProjectDeployerRequest pdr = new ProjectDeployerRequest()
+                .setProject( executionEvent.getSession().getTopLevelProject() )
+                .setRetryFailedDeploymentCount( retryFailedDeploymentCount )
+                .setAltReleaseDeploymentRepository( altReleaseDeploymentRepository )
+                .setAltSnapshotDeploymentRepository( altSnapshotDeploymentRepository )
+                .setAltDeploymentRepository( altDeploymentRepository );
+
+        return getDeploymentRepository(pdr);
+    }
+
+    protected ArtifactRepository getDeploymentRepository( ProjectDeployerRequest pdr )
+
+            throws MojoExecutionException, MojoFailureException
+    {
+        MavenProject project = pdr.getProject();
+        String altDeploymentRepository = pdr.getAltDeploymentRepository();
+        String altReleaseDeploymentRepository = pdr.getAltReleaseDeploymentRepository();
+        String altSnapshotDeploymentRepository = pdr.getAltSnapshotDeploymentRepository();
+
+        ArtifactRepository repo = null;
+
+        String altDeploymentRepo;
+        if ( ArtifactUtils.isSnapshot( project.getVersion() ) && altSnapshotDeploymentRepository != null )
+        {
+            altDeploymentRepo = altSnapshotDeploymentRepository;
+        }
+        else if ( !ArtifactUtils.isSnapshot( project.getVersion() ) && altReleaseDeploymentRepository != null )
+        {
+            altDeploymentRepo = altReleaseDeploymentRepository;
+        }
+        else
+        {
+            altDeploymentRepo = altDeploymentRepository;
+        }
+
+        if ( altDeploymentRepo != null )
+        {
+            LOGGER.info( "Using alternate deployment repository " + altDeploymentRepo );
+
+            Matcher matcher = ALT_REPO_SYNTAX_PATTERN.matcher( altDeploymentRepo );
+
+            if ( !matcher.matches() )
+            {
+                throw new MojoFailureException( altDeploymentRepo, "Invalid syntax for repository.",
+                        "Invalid syntax for alternative repository. Use \"id::url\"." );
+            }
+            else
+            {
+                String id = matcher.group( 1 ).trim();
+                String url = matcher.group( 2 ).trim();
+
+                repo = createDeploymentArtifactRepository( id, url );
+            }
+        }
+
+        if ( repo == null )
+        {
+            repo = project.getDistributionManagementArtifactRepository();
+        }
+
+        if ( repo == null )
+        {
+            String msg = "Deployment failed: repository element was not specified in the POM inside"
+                    + " distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter";
+
+            throw new MojoExecutionException( msg );
+        }
+
+        return repo;
+    }
+
+    protected ArtifactRepository createDeploymentArtifactRepository( String id, String url )
+    {
+        return new MavenArtifactRepository( id, url, new DefaultRepositoryLayout(), new ArtifactRepositoryPolicy(),
+                new ArtifactRepositoryPolicy() );
+    }
+}

--- a/src/test/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolverTest.java
+++ b/src/test/java/com/soebes/maven/extensions/deployer/ArtifactRepositoryResolverTest.java
@@ -1,0 +1,157 @@
+package com.soebes.maven.extensions.deployer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.transfer.project.deploy.ProjectDeployerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ArtifactRepositoryResolverTest {
+
+    @Mock
+    private MavenProject mavenProject;
+
+    @Mock
+    private ArtifactRepository defaultDistributionManagementRepo;
+
+
+
+
+    @BeforeEach
+    public void setUp() {
+
+    }
+
+    @Test
+    public void testDefaultDeploymentRepoRequest() throws MojoFailureException, MojoExecutionException {
+
+        when(mavenProject.getDistributionManagementArtifactRepository()).thenReturn(defaultDistributionManagementRepo);
+        when(mavenProject.getVersion()).thenReturn("1.0.0");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject);
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        ArtifactRepository resolvedRepo = resolver.getDeploymentRepository(dpr);
+        assertEquals(defaultDistributionManagementRepo, resolvedRepo);
+    }
+
+
+    @Test
+    public void testAltNormalRepository() throws MojoFailureException, MojoExecutionException {
+
+        when(mavenProject.getVersion()).thenReturn("1.0.0");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject)
+                .setAltDeploymentRepository("TestRepo::http://localhost:8080/test");
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        ArtifactRepository resolvedRepo = resolver.getDeploymentRepository(dpr);
+
+        assertEquals("TestRepo", resolvedRepo.getKey());
+        assertEquals("http://localhost:8080/test", resolvedRepo.getUrl());
+
+    }
+
+    @Test
+    public void testAltSnapshotRepositoryButNormalVersionReturnsNormalRepository()
+            throws MojoFailureException, MojoExecutionException {
+
+        when(mavenProject.getDistributionManagementArtifactRepository()).thenReturn(defaultDistributionManagementRepo);
+        when(mavenProject.getVersion()).thenReturn("1.0.0");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject)
+                .setAltSnapshotDeploymentRepository("TestRepo::http://localhost/");
+
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        ArtifactRepository resolvedRepo = resolver.getDeploymentRepository(dpr);
+        assertEquals(defaultDistributionManagementRepo, resolvedRepo);
+    }
+
+    @Test
+    public void testAltSnapshotRepository() throws MojoFailureException, MojoExecutionException {
+        when(mavenProject.getVersion()).thenReturn("1.0.0-SNAPSHOT");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject)
+                .setAltSnapshotDeploymentRepository("TestSnapshotRepo::http://localhost:8080/snapshot");
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        ArtifactRepository resolvedRepo = resolver.getDeploymentRepository(dpr);
+
+        assertEquals("TestSnapshotRepo", resolvedRepo.getKey());
+        assertEquals("http://localhost:8080/snapshot", resolvedRepo.getUrl());
+    }
+
+    @Test
+    public void testAltReleaseRepository() throws MojoFailureException, MojoExecutionException {
+        when(mavenProject.getVersion()).thenReturn("1.2.0");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject)
+                .setAltReleaseDeploymentRepository("TestReleaseRepo::http://localhost:8080/releases");
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        ArtifactRepository resolvedRepo = resolver.getDeploymentRepository(dpr);
+
+        assertEquals("TestReleaseRepo", resolvedRepo.getKey());
+        assertEquals("http://localhost:8080/releases", resolvedRepo.getUrl());
+    }
+
+
+    @Test
+    public void testNoResolutionThrowsMojoExecutionException() {
+        //Attempts resolution of snapshot repo but only deployment repo provided
+        when(mavenProject.getVersion()).thenReturn("1.1.0-SNAPSHOT");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject)
+                .setAltReleaseDeploymentRepository("TestReleaseRepo::http://localhost:8080/releases");
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        assertThrows(MojoExecutionException.class, () -> resolver.getDeploymentRepository(dpr));
+    }
+
+
+    @Test
+    public void testInvalidRepoThrowsMojoFailureExecption() {
+        //Attempts resolution of snapshot repo but only deployment repo provided
+        when(mavenProject.getVersion()).thenReturn("1.1.0");
+
+        //No alt properties
+        ProjectDeployerRequest dpr = new ProjectDeployerRequest()
+                .setProject(mavenProject)
+                .setAltReleaseDeploymentRepository("http://localhost:8080/releases");
+
+        ArtifactRepositoryResolver resolver = new ArtifactRepositoryResolver();
+
+        assertThrows(MojoFailureException.class, () -> resolver.getDeploymentRepository(dpr));
+    }
+
+
+}


### PR DESCRIPTION
Hi,  I don't expect this PR to be merged, but more start a discussion.  (There's a few incompatible changes I made for our local development jdk8 + junit5 for example).

The big changes:

* Support the "Alt Repository" options that are available in maven-deployer plugin
* Fix exception handling -- if a deployment failed, maven thought the build succeeded.

Feel free to slash away at it to make it compatible + your own integration test environment.   

I hope this helps.
-Mike